### PR TITLE
Restore service visuals and assistant copy from JSON

### DIFF
--- a/public/data/assicurazioni-russo.json
+++ b/public/data/assicurazioni-russo.json
@@ -159,6 +159,29 @@
       }
     ]
   },
+  "assistant": {
+    "eyebrow": "assistente digitale",
+    "title": "Il consulente digitale di Assicurazioni Russo",
+    "subtitle": "Disponibile 24/7 per orientarti tra preventivi e richieste di sinistro.",
+    "description": "Raccoglie le informazioni che ci invii online, le inoltra al team e ti suggerisce il canale più veloce per completare la pratica.",
+    "highlights": [
+      {
+        "icon": "shield",
+        "title": "Profilo protetto",
+        "text": "Analizza le esigenze di guida, casa o professione e propone le coperture più adatte."
+      },
+      {
+        "icon": "bot",
+        "title": "Preventivi in tempo reale",
+        "text": "Pre-compila il preventivo RC Auto, casa, salute o professionale e ti aggiorna su documenti e scadenze."
+      },
+      {
+        "icon": "message",
+        "title": "Supporto sinistri",
+        "text": "Ti guida nell'apertura del sinistro e inoltra subito il riepilogo al nostro staff."
+      }
+    ]
+  },
   "story": {
     "title": "Dal preventivo alla gestione del sinistro",
     "text": "Siamo consulenti, non solo venditori: analizziamo i rischi reali e cuciamo le garanzie su misura. Assistiamo i clienti anche in caso di sinistro per accorciare tempi e burocrazia."

--- a/public/data/de-santis.json
+++ b/public/data/de-santis.json
@@ -87,5 +87,28 @@
         ]
       }
     ]
+  },
+  "assistant": {
+    "eyebrow": "assistente",
+    "title": "La pasticceria digitale di De Santis",
+    "subtitle": "Risponde subito su dolci, ordini personalizzati e disponibilità giornaliera.",
+    "description": "Utilizza il listino aggiornato per consigliare cornetti, torte e buffet, raccogliendo le richieste per eventi e ricorrenze.",
+    "highlights": [
+      {
+        "icon": "sparkles",
+        "title": "Vetrina del giorno",
+        "text": "Comunica cosa esce dal forno e segnala i prodotti più richiesti dalla clientela."
+      },
+      {
+        "icon": "message",
+        "title": "Ordini su misura",
+        "text": "Raccoglie gusti, dimensioni e date per torte e buffet e inoltra subito la richiesta al laboratorio."
+      },
+      {
+        "icon": "phone",
+        "title": "Supporto rapido",
+        "text": "Indica orari, contatti e modalità di ritiro o consegna quando serve una risposta immediata."
+      }
+    ]
   }
 }

--- a/public/data/dentista-michele-lamberti.json
+++ b/public/data/dentista-michele-lamberti.json
@@ -90,6 +90,29 @@
       }
     ]
   },
+  "assistant": {
+    "eyebrow": "assistente",
+    "title": "Assistente digitale dello Studio Aurora",
+    "subtitle": "Accompagna i pazienti tra visite, igiene e percorsi specialistici.",
+    "description": "Offre informazioni aggiornate su preventivi, tecnologie e disponibilità, inoltrando le richieste allo staff.",
+    "highlights": [
+      {
+        "icon": "shield",
+        "title": "Informazioni accurate",
+        "text": "Spiega protocolli di prevenzione, implantologia e ortodonzia seguendo le linee guida dello studio."
+      },
+      {
+        "icon": "bot",
+        "title": "Prenotazioni smart",
+        "text": "Raccoglie dati per prima visita, igiene e controlli proponendo gli slot disponibili."
+      },
+      {
+        "icon": "message",
+        "title": "Supporto post-visita",
+        "text": "Ricorda documenti, piani di pagamento e recapiti per gestire eventuali urgenze."
+      }
+    ]
+  },
   "story": {
     "title": "Cura, tecnologia e sorriso",
     "text": "Da oltre 10 anni ci occupiamo di prevenzione, implantologia e ortodonzia con tecnologie digitali (radiologia 3D, scanner intraorale). L’approccio è personalizzato e centrato sul comfort del paziente."

--- a/public/data/il-pirata.json
+++ b/public/data/il-pirata.json
@@ -94,5 +94,28 @@
         ]
       }
     ]
+  },
+  "assistant": {
+    "eyebrow": "assistente",
+    "title": "Il Pirata sempre con te",
+    "subtitle": "Consiglia impasti, fritti e brace gestendo richieste e prenotazioni in tempo reale.",
+    "description": "Parla con il tono della pizzeria e usa solo informazioni ufficiali per guidare gli ospiti tra pizze, fritti e carne alla brace.",
+    "highlights": [
+      {
+        "icon": "sparkles",
+        "title": "Consigli del giorno",
+        "text": "Ricorda le proposte speciali come la Margherita XL o i tagli di brace disponibili la sera."
+      },
+      {
+        "icon": "bot",
+        "title": "Ordini su misura",
+        "text": "Gestisce richieste senza lattosio o vegetariane e suggerisce gli abbinamenti migliori."
+      },
+      {
+        "icon": "map",
+        "title": "Assistenza clienti",
+        "text": "Invia orari, indicazioni e contatti per prenotare tavoli o organizzare il ritiro."
+      }
+    ]
   }
 }

--- a/public/data/marcello-barber-salon.json
+++ b/public/data/marcello-barber-salon.json
@@ -96,5 +96,28 @@
         ]
       }
     ]
+  },
+  "assistant": {
+    "eyebrow": "assistente digitale",
+    "title": "Il barber assistant di Marcello",
+    "subtitle": "Ti accompagna tra tagli sartoriali, barba e prodotti da portare a casa.",
+    "description": "Raccoglie richieste di appuntamento e propone look coerenti con lo stile del salone, ricordando promozioni e prodotti professionali.",
+    "highlights": [
+      {
+        "icon": "sparkles",
+        "title": "Consigli di stile",
+        "text": "Suggerisce i tagli e le combinazioni più richieste spiegando come mantenerle dopo il servizio."
+      },
+      {
+        "icon": "bot",
+        "title": "Agenda smart",
+        "text": "Registra la richiesta con giorno e servizio preferito e inoltra il riepilogo per la conferma."
+      },
+      {
+        "icon": "phone",
+        "title": "Cura continua",
+        "text": "Indica prodotti consigliati, prezzi e modalità di ritiro direttamente in salone."
+      }
+    ]
   }
 }

--- a/public/data/zen-cafe.json
+++ b/public/data/zen-cafe.json
@@ -94,5 +94,28 @@
         ]
       }
     ]
+  },
+  "assistant": {
+    "eyebrow": "assistente digitale",
+    "title": "L’assistente di Zen Cafè",
+    "subtitle": "Sempre pronto a raccontarti colazioni, aperitivi e pizze leggere.",
+    "description": "Risponde con il tono rilassato del locale e suggerisce abbinamenti partendo dal menu aggiornato.",
+    "highlights": [
+      {
+        "icon": "sparkles",
+        "title": "Mood del momento",
+        "text": "Segnala le proposte speciali come l’Aperitivo Zen o le pizze gourmet disponibili."
+      },
+      {
+        "icon": "message",
+        "title": "Scelte personalizzate",
+        "text": "Propone alternative senza lattosio o vegetariane e ti indirizza verso ciò che cerchi."
+      },
+      {
+        "icon": "map",
+        "title": "Assistenza continua",
+        "text": "Condivide orari, contatti e come raggiungerci per una pausa o un take-away."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- reintroduce service card media with animated gradient styling for a richer layout
- map assistant section content to new venue-specific data and surface it in the UI
- extend venue JSON files with curated assistant copy tailored to each business

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d68d933da083318f8b1e5fd2be2e2c