### PR TITLE
Add primary CTAs and hero stats to venue configs

### DIFF
--- a/public/data/assicurazioni-russo.json
+++ b/public/data/assicurazioni-russo.json
@@ -41,7 +41,17 @@
         { "type": "directions", "label": "Vieni in agenzia" }
       ],
       "initialMessage": "Ciao! Posso guidarti al miglior preventivo per auto, casa, salute, infortuni o professione. Da dove partiamo?"
-    }
+    },
+    "primaryCta": {
+      "label": "Scrivici su WhatsApp",
+      "url": "https://wa.me/393202224455?text=Ciao%20Assicurazioni%20Russo%2C%20vorrei%20un%20preventivo.",
+      "description": "Preventivi immediati e assistenza sinistri in tempo reale."
+    },
+    "heroStats": [
+      { "value": "30+", "label": "Compagnie partner" },
+      { "value": "24h", "label": "Supporto sinistri", "sublabel": "anche via WhatsApp" },
+      { "label": "Consulenze su misura per famiglie e imprese" }
+    ]
   },
   "menu": {
     "specials": [

--- a/public/data/de-santis.json
+++ b/public/data/de-santis.json
@@ -53,7 +53,17 @@
     { "type": "directions", "label": "Indicazioni" },
     { "type": "whatsapp", "label": "WhatsApp" }
   ]
-}
+},
+    "primaryCta": {
+      "label": "Ordina su WhatsApp",
+      "url": "https://wa.me/393334445555?text=Ciao%20De%20Santis%2C%20vorrei%20ordinare%20una%20torta.",
+      "description": "Prenota dolci personalizzati e ritiri veloci."
+    },
+    "heroStats": [
+      { "value": "1985", "label": "Anno di apertura" },
+      { "value": "7/7", "label": "Pane fresco ogni giorno" },
+      { "label": "Ordini personalizzati per eventi e cerimonie" }
+    ]
   },
   "story": {
     "title": "Dolci di famiglia",

--- a/public/data/dentista-michele-lamberti.json
+++ b/public/data/dentista-michele-lamberti.json
@@ -44,7 +44,17 @@
         { "type": "directions", "label": "Come arrivare" }
       ],
       "initialMessage": "Ciao! Posso aiutarti con visite, preventivi, igiene, sbiancamento, ortodonzia o implantologia. Vuoi fissare un appuntamento?"
-    }
+    },
+    "primaryCta": {
+      "label": "Prenota su WhatsApp",
+      "url": "https://wa.me/393339876543?text=Buongiorno%2C%20vorrei%20prenotare%20una%20visita%20allo%20Studio%20Aurora.",
+      "description": "Fissa controlli, igiene e trattamenti in pochi minuti."
+    },
+    "heroStats": [
+      { "value": "10+", "label": "Anni di esperienza" },
+      { "value": "3D", "label": "Radiologia digitale", "sublabel": "Scanner intraorale e panoramica" },
+      { "label": "Piani di pagamento rateali disponibili" }
+    ]
   },
   "menu": {
     "specials": [

--- a/public/data/il-pirata.json
+++ b/public/data/il-pirata.json
@@ -54,7 +54,17 @@
     { "type": "directions", "label": "Indicazioni" },
     { "type": "whatsapp", "label": "WhatsApp" }
   ]
-    }
+    },
+    "primaryCta": {
+      "label": "Prenota su WhatsApp",
+      "url": "https://wa.me/393331234567?text=Ciao%20Il%20Pirata%2C%20vorrei%20prenotare%20un%20tavolo.",
+      "description": "Prenotazioni e ordini d'asporto in tempo reale."
+    },
+    "heroStats": [
+      { "value": "Dal 1998", "label": "Tradizione di quartiere" },
+      { "value": "48h", "label": "Lievitazione degli impasti" },
+      { "label": "Brace accesa ogni sera" }
+    ]
   },
   "story": {
     "title": "La storia del Pirata",

--- a/public/data/marcello-barber-salon.json
+++ b/public/data/marcello-barber-salon.json
@@ -53,7 +53,17 @@
     { "type": "directions", "label": "Indicazioni" },
     { "type": "whatsapp", "label": "WhatsApp" }
   ]
-}
+},
+    "primaryCta": {
+      "label": "Prenota su WhatsApp",
+      "url": "https://wa.me/393334455667?text=Ciao%20Marcello%2C%20vorrei%20prenotare%20un%20taglio%20o%20barba.",
+      "description": "Scegli giorno e servizio per taglio, barba e grooming."
+    },
+    "heroStats": [
+      { "value": "3", "label": "Barber senior", "sublabel": "Team dedicato allo stile" },
+      { "value": "20", "label": "Posti al giorno", "sublabel": "Prenotazione consigliata" },
+      { "label": "Prodotti professionali sempre disponibili" }
+    ]
   },
   "story": {
     "title": "Lo stile di Marcello",

--- a/public/data/zen-cafe.json
+++ b/public/data/zen-cafe.json
@@ -53,7 +53,17 @@
     { "type": "directions", "label": "Indicazioni" },
     { "type": "whatsapp", "label": "WhatsApp" }
   ]
-}
+},
+    "primaryCta": {
+      "label": "Scrivici su WhatsApp",
+      "url": "https://wa.me/393331112222?text=Ciao%20Zen%20Caf%C3%A8%2C%20vorrei%20prenotare%20un%20aperitivo.",
+      "description": "Prenota aperitivi, pizze gourmet e feste private."
+    },
+    "heroStats": [
+      { "value": "48h", "label": "Lievitazione degli impasti" },
+      { "value": "7:00", "label": "Apertura ogni mattina" },
+      { "label": "Aperitivi personalizzati su prenotazione" }
+    ]
   },
   "story": {
     "title": "Relax & buon gusto",


### PR DESCRIPTION
## Summary
- add venue-specific primary WhatsApp CTAs across all venue JSON configs
- populate heroStats values for each venue so the hero section shows real metrics

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d7dbfc2ae48331bc4c9d22e4cad3cf