### PR TITLE
Add configurable assistant hero description for venues

### DIFF
--- a/public/data/assicurazioni-russo.json
+++ b/public/data/assicurazioni-russo.json
@@ -16,6 +16,7 @@
     "lastUpdated": "2025-09-05",
     "footerNote": "Premi indicativi ‘da’: il premio effettivo dipende da profilo, garanzie e condizioni.",
     "assistantLabel": "Chiedi a Assicurazioni Russo",
+    "assistantHeroDescription": "L’assistente digitale di Assicurazioni Russo raccoglie le tue esigenze e prepara confronti su polizze auto, casa e professionali prima della consulenza con un agente.",
     "instagramUrl": "https://www.instagram.com/assicurazioniverdi",
     "facebookUrl": "https://www.facebook.com/assicurazioniverdi",
     "onlineBadgeLabel": "Preventivi rapidi",

--- a/public/data/de-santis.json
+++ b/public/data/de-santis.json
@@ -13,6 +13,7 @@
     "logoUrl": "/desantis/desantis_favicon.svg",
     "heroImages": ["/desantis/de-santis-1.jpg", "/desantis/de-santis-2.jpg"],
     "assistantLabel": "Chiedi a De Santis",
+    "assistantHeroDescription": "Chiedi disponibilità di pane caldo, rustici e torte su misura: l’assistente di De Santis risponde subito su ingredienti, allergeni e tempi di ritiro.",
     "footerNote": "Pasticceria fresca ogni giorno. Ordini personalizzati per eventi.",
     "lastUpdated": "2025-09-05",
     "onlineBadgeLabel": "Dolci online",

--- a/public/data/dentista-michele-lamberti.json
+++ b/public/data/dentista-michele-lamberti.json
@@ -17,6 +17,7 @@
     "lastUpdated": "2025-09-05",
     "footerNote": "Tariffe indicative: il preventivo è sempre personalizzato dopo visita e diagnosi.",
     "assistantLabel": "Chiedi allo Studio Aurora",
+    "assistantHeroDescription": "L’assistente dello Studio Dentistico Aurora chiarisce trattamenti, tempi di recupero e piani di pagamento così arrivi alla prima visita già informato.",
     "instagramUrl": "https://www.instagram.com/studiodentisticoaurora",
     "facebookUrl": "https://www.facebook.com/studiodentisticoaurora",
     "onlineBadgeLabel": "Prenota o chiedi info",

--- a/public/data/il-pirata.json
+++ b/public/data/il-pirata.json
@@ -13,6 +13,7 @@
     "logoUrl": "/pirata/pirate_logo_colored.png",
     "heroImages": ["/pirata/ilpirata-6.jpg", "/pirata/ilpirata-7.jpg", "/pirata/ilpirata-8.jpg"],
     "assistantLabel": "Chiedi al Pirata",
+    "assistantHeroDescription": "L’assistente de Il Pirata ti racconta impasti, cotture e promo del giorno per guidarti tra pizze, brace e fritti senza attese.",
     "footerNote": "Dal 1998 sforniamo pizze a lenta lievitazione. Farine selezionate e ingredienti locali.",
     "lastUpdated": "2025-09-05",
     "searchPlaceholder": "Cerca pizza o ingrediente…",

--- a/public/data/marcello-barber-salon.json
+++ b/public/data/marcello-barber-salon.json
@@ -19,6 +19,7 @@
       "text": ""
     },
     "assistantLabel": "Chiedi al Barber",
+    "assistantHeroDescription": "L’assistente di Marcello Barber Salon suggerisce tagli, combo barba e prodotti di styling, verificando subito disponibilità e prezzi aggiornati.",
     "footerNote": "Grooming di qualità, prodotti professionali e stile su misura. Prenota il tuo momento.",
     "lastUpdated": "2025-09-10",
     "theme": {

--- a/public/data/zen-cafe.json
+++ b/public/data/zen-cafe.json
@@ -13,6 +13,7 @@
     "logoUrl": "/zen/zen_logo_transparent.svg",
     "heroImages": ["/zen/zen-1.jpg", "/zen/zen-2.jpg", "/zen/zen-3.jpg"],
     "assistantLabel": "Chiedi allo Zen Cafè",
+    "assistantHeroDescription": "L’assistente dello Zen Cafè ti suggerisce combo colazione, aperitivi e pizze del giorno con info su allergeni e prenotazioni rapide per il tuo tavolo.",
     "footerNote": "Impasti leggeri 48h e caffetteria selezionata.",
     "lastUpdated": "2025-09-05",
     "searchPlaceholder": "Cerca pizza o ingrediente…",

--- a/src/SianoVenue.tsx
+++ b/src/SianoVenue.tsx
@@ -61,6 +61,7 @@ type Config = {
   lastUpdated?: string;
   footerNote?: string;
   assistantLabel?: string;
+  assistantHeroDescription?: string;
 
   /** personalizzazioni UI */
   onlineBadgeLabel?: string | null;
@@ -289,10 +290,16 @@ function useVenueData() {
           ? primaryCtaCandidate
           : undefined;
 
+        const assistantHeroDescription =
+          typeof c.assistantHeroDescription === "string" && c.assistantHeroDescription.trim()
+            ? c.assistantHeroDescription.trim()
+            : undefined;
+
         const sanitizedConfig: Config = {
           ...c,
           heroStats,
           primaryCta,
+          assistantHeroDescription,
         };
         const m = (json.menu || {}) as Menu;
         m.categories = Array.isArray(m.categories) ? m.categories : [];
@@ -457,6 +464,9 @@ function Hero({ cfg, badgeLabel }: { cfg: Config; badgeLabel: string | null }) {
   }, [cfg.primaryCta, cfg.whatsapp, cfg.whatsDefaultMsg, cfg.phone]);
   const primaryCtaUrl = primaryCta.url || "#";
   const primaryCtaIsExternal = /^https?:/i.test(primaryCtaUrl);
+  const assistantHeroDescription =
+    cfg.assistantHeroDescription ||
+    `Risposte immediate su servizi, disponibilità, preventivi e follow-up. L’assistente AI attinge solo dalle informazioni pubblicate da ${cfg.name}, così i tuoi clienti hanno sempre un punto di contatto affidabile, 24/7.`;
 
   React.useEffect(() => {
     if (images.length <= 1) return;
@@ -594,11 +604,7 @@ function Hero({ cfg, badgeLabel }: { cfg: Config; badgeLabel: string | null }) {
                   <p className="font-medium text-[color:var(--text)]">
                     {cfg.assistantLabel || "Assistente AI dedicato"}
                   </p>
-                  <p className="mt-1 text-[color:var(--textSoft)]">
-                    Risposte immediate su servizi, disponibilità, preventivi e follow-up. L’assistente AI attinge solo
-                    dalle informazioni pubblicate da {cfg.name}, così i tuoi clienti hanno sempre un punto di contatto
-                    affidabile, 24/7.
-                  </p>
+                  <p className="mt-1 text-[color:var(--textSoft)]">{assistantHeroDescription}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add an optional `assistantHeroDescription` to the venue config and sanitize it when loading data
- render the hero card description from configuration while retaining the previous copy as the fallback
- populate the new description field in every venue JSON with venue-specific messaging

## Testing
- npm run dev -- --host 0.0.0.0 --port 5175

------
https://chatgpt.com/codex/tasks/task_e_68d7dd82d09c83319acb1235bde30431