### PR TITLE
Add parallax hero video support

### DIFF
--- a/public/data/assicurazioni-russo.json
+++ b/public/data/assicurazioni-russo.json
@@ -13,6 +13,12 @@
       "/nellorussohdi/hdi_image_01.png",
       "/nellorussohdi/hdi_image_02.jpg"
     ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-modern-office-meeting-5718/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/aurora-veils.svg",
+      "/overlays/particles-dust.svg"
+    ],
+    "heroAuroraColors": ["#0e7490", "#22d3ee", "#0f172a"],
     "lastUpdated": "2025-09-05",
     "footerNote": "Premi indicativi ‘da’: il premio effettivo dipende da profilo, garanzie e condizioni.",
     "assistantLabel": "Chiedi a Assicurazioni Russo",

--- a/public/data/de-santis.json
+++ b/public/data/de-santis.json
@@ -11,7 +11,16 @@
     "instagramUrl": "https://instagram.com/tua_pagina",
     "facebookUrl": "https://facebook.com/tua_pagina",
     "logoUrl": "/desantis/desantis_favicon.svg",
-    "heroImages": ["/desantis/de-santis-1.jpg", "/desantis/de-santis-2.jpg"],
+    "heroImages": [
+      "/desantis/de-santis-1.jpg",
+      "/desantis/de-santis-2.jpg"
+    ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-confectioner-decorating-cake-0508/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/flare-soft.svg",
+      "/overlays/particles-dust.svg"
+    ],
+    "heroAuroraColors": ["#be123c", "#f97316", "#fde047"],
     "assistantLabel": "Chiedi a De Santis",
     "assistantHeroDescription": "Chiedi disponibilità di pane caldo, rustici e torte su misura: l’assistente di De Santis risponde subito su ingredienti, allergeni e tempi di ritiro.",
     "footerNote": "Pasticceria fresca ogni giorno. Ordini personalizzati per eventi.",

--- a/public/data/dentista-michele-lamberti.json
+++ b/public/data/dentista-michele-lamberti.json
@@ -14,6 +14,12 @@
       "/img/venues/dentista-aurora-2.jpg",
       "/img/venues/dentista-aurora-3.jpg"
     ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-dentist-checking-patients-teeth-7349/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/flare-soft.svg",
+      "/overlays/aurora-veils.svg"
+    ],
+    "heroAuroraColors": ["#b91c1c", "#f97316", "#fbcfe8"],
     "lastUpdated": "2025-09-05",
     "footerNote": "Tariffe indicative: il preventivo è sempre personalizzato dopo visita e diagnosi.",
     "assistantLabel": "Chiedi allo Studio Aurora",

--- a/public/data/il-pirata.json
+++ b/public/data/il-pirata.json
@@ -11,7 +11,17 @@
     "instagramUrl": "https://instagram.com/tua_pagina",
     "facebookUrl": "https://facebook.com/tua_pagina",
     "logoUrl": "/pirata/pirate_logo_colored.png",
-    "heroImages": ["/pirata/ilpirata-6.jpg", "/pirata/ilpirata-7.jpg", "/pirata/ilpirata-8.jpg"],
+    "heroImages": [
+      "/pirata/ilpirata-6.jpg",
+      "/pirata/ilpirata-7.jpg",
+      "/pirata/ilpirata-8.jpg"
+    ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-pouring-flour-into-a-bowl-2215/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/flare-soft.svg",
+      "/overlays/particles-dust.svg"
+    ],
+    "heroAuroraColors": ["#e11d48", "#fb7185", "#f59e0b"],
     "assistantLabel": "Chiedi al Pirata",
     "assistantHeroDescription": "L’assistente de Il Pirata ti racconta impasti, cotture e promo del giorno per guidarti tra pizze, brace e fritti senza attese.",
     "footerNote": "Dal 1998 sforniamo pizze a lenta lievitazione. Farine selezionate e ingredienti locali.",

--- a/public/data/marcello-barber-salon.json
+++ b/public/data/marcello-barber-salon.json
@@ -11,7 +11,17 @@
     "instagramUrl": "https://instagram.com/tua_pagina",
     "facebookUrl": "https://facebook.com/tua_pagina",
     "logoUrl": "/marcello/logo_1.png",
-    "heroImages": ["/marcello/marcello-1.jpg", "/marcello/marcello-2.jpg", "/marcello/marcello-3.jpg"],
+    "heroImages": [
+      "/marcello/marcello-1.jpg",
+      "/marcello/marcello-2.jpg",
+      "/marcello/marcello-3.jpg"
+    ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-barber-shaving-client-9460/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/particles-dust.svg",
+      "/overlays/aurora-veils.svg"
+    ],
+    "heroAuroraColors": ["#c9a227", "#facc15", "#fde68a"],
     "onlineBadgeLabel": "Catalogo Online",
     "searchPlaceholder": "Cerca taglio, barba o prodotto…",
     "allergenNotice": {             

--- a/public/data/zen-cafe.json
+++ b/public/data/zen-cafe.json
@@ -11,7 +11,17 @@
     "instagramUrl": "https://instagram.com/tua_pagina",
     "facebookUrl": "https://facebook.com/tua_pagina",
     "logoUrl": "/zen/zen_logo_transparent.svg",
-    "heroImages": ["/zen/zen-1.jpg", "/zen/zen-2.jpg", "/zen/zen-3.jpg"],
+    "heroImages": [
+      "/zen/zen-1.jpg",
+      "/zen/zen-2.jpg",
+      "/zen/zen-3.jpg"
+    ],
+    "heroVideoUrl": "https://cdn.coverr.co/videos/coverr-pouring-a-cocktail-into-a-glass-9719/1080p.mp4",
+    "heroOverlays": [
+      "/overlays/aurora-veils.svg",
+      "/overlays/particles-dust.svg"
+    ],
+    "heroAuroraColors": ["#6d28d9", "#a855f7", "#6366f1"],
     "assistantLabel": "Chiedi allo Zen Cafè",
     "assistantHeroDescription": "L’assistente dello Zen Cafè ti suggerisce combo colazione, aperitivi e pizze del giorno con info su allergeni e prenotazioni rapide per il tuo tavolo.",
     "footerNote": "Impasti leggeri 48h e caffetteria selezionata.",

--- a/public/overlays/aurora-veils.svg
+++ b/public/overlays/aurora-veils.svg
@@ -1,0 +1,14 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="veilA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0.12" />
+      <stop offset="1" stop-color="white" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="veilB" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0.16" />
+      <stop offset="1" stop-color="white" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <path d="M0 180C160 80 320 40 600 120C880 200 1120 120 1200 60V1200H0V180Z" fill="url(#veilA)" />
+  <path d="M0 420C200 560 480 600 700 540C900 484 1120 360 1200 280V1200H0V420Z" fill="url(#veilB)" />
+</svg>

--- a/public/overlays/flare-soft.svg
+++ b/public/overlays/flare-soft.svg
@@ -1,0 +1,14 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(300 320) scale(420)">
+      <stop stop-color="white" stop-opacity="0.8" />
+      <stop offset="1" stop-color="white" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="g2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(900 760) scale(520)">
+      <stop stop-color="white" stop-opacity="0.6" />
+      <stop offset="1" stop-color="white" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="1200" fill="url(#g1)" />
+  <rect width="1200" height="1200" fill="url(#g2)" />
+</svg>

--- a/public/overlays/particles-dust.svg
+++ b/public/overlays/particles-dust.svg
@@ -1,0 +1,17 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="1200" fill="url(#noise)" opacity="0.4" />
+  <defs>
+    <pattern id="noise" x="0" y="0" width="160" height="160" patternUnits="userSpaceOnUse">
+      <g fill="white">
+        <circle cx="12" cy="24" r="1.4" fill-opacity="0.5" />
+        <circle cx="54" cy="56" r="1" fill-opacity="0.35" />
+        <circle cx="120" cy="32" r="1.6" fill-opacity="0.5" />
+        <circle cx="42" cy="110" r="1.2" fill-opacity="0.35" />
+        <circle cx="88" cy="148" r="1.8" fill-opacity="0.45" />
+        <circle cx="146" cy="86" r="1.1" fill-opacity="0.35" />
+        <circle cx="18" cy="150" r="1.5" fill-opacity="0.4" />
+        <circle cx="76" cy="84" r="1" fill-opacity="0.32" />
+      </g>
+    </pattern>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- extend the venue configuration to support hero video, overlay, and aurora color settings while sanitising the loaded data
- rework the hero component with layered parallax, optional looping video playback, and animated aurora particles driven by Framer Motion
- provide overlay assets and update venue JSON payloads with the new media references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7e41cf42883318cc3180687b8ebc9